### PR TITLE
Lazy loading

### DIFF
--- a/src/boundary-list.js
+++ b/src/boundary-list.js
@@ -31,6 +31,7 @@ export class BoundaryList {
             let desc = overlay.type == 'tooltip' ? boundary.description : null;
             boundary.overlayDivs[overlayId] = [];
 
+            console.log(nodes);
             nodes.forEach(function (node) {
                 let overlayDiv = attachDivOverlay(node, className, desc, overlay.styles);
                 boundary.overlayDivs[overlayId].push(overlayDiv);

--- a/src/boundary-list.js
+++ b/src/boundary-list.js
@@ -73,9 +73,8 @@ export class BoundaryList {
         }
         // Update the list of added nodes, and attach overlays if applicable
         return matchedNodes.then(function(nodes) {
-            boundary.pushAddedNodes(nodes);
             if (boundary.overlays !== undefined) {
-                this.createOverlays(matchedNodes, boundary);
+                this.createOverlays(nodes, boundary);
             }
             return boundary;
         }.bind(this));    
@@ -91,6 +90,7 @@ export class BoundaryList {
         this.boundaries.forEach(function (boundary) {
             if (boundary.selectorType === 'link-query-lazy') {
                 linkQueryLazy(boundary, document.body, function(node) {
+                    console.log('test');
                     console.log(node);
                     this.performBoundaryAction([node], boundary);
                     boundary.pushAddedNodes([node]);

--- a/src/boundary-list.js
+++ b/src/boundary-list.js
@@ -18,7 +18,7 @@ export class BoundaryList {
         Creates elements corresponding to a boundary's overlays.
         @param boundary: the given Boundary object.
     */
-   createOverlays(boundary) {
+   createOverlays(nodes, boundary) {
         if (boundary.overlayDivs == undefined) {
             boundary.overlayDivs = {};
         }
@@ -29,7 +29,7 @@ export class BoundaryList {
             let desc = overlay.type == 'tooltip' ? boundary.description : null;
             boundary.overlayDivs[overlayId] = [];
 
-            boundary.affectedNodes.forEach(function (node) {
+            nodes.forEach(function (node) {
                 let overlayDiv = attachDivOverlay(node, className, desc, overlay.styles);
                 boundary.overlayDivs[overlayId].push(overlayDiv);
                 node.style.position = 'relative';
@@ -73,7 +73,7 @@ export class BoundaryList {
         return matchedNodes.then(function(nodes) {
             boundary.pushAddedNodes(nodes);
             if (boundary.overlays !== undefined) {
-                this.createOverlays(boundary);
+                this.createOverlays(matchedNodes, boundary);
             }
             return boundary;
         }.bind(this));    
@@ -92,6 +92,9 @@ export class BoundaryList {
                     console.log(node);
                     this.performBoundaryAction([node], boundary);
                     boundary.pushAddedNodes([node]);
+                    if (boundary.overlays !== undefined) {
+                        this.createOverlays([node], boundary);
+                    }
                 }.bind(this));
                 onLoadCallback(boundary);
             } else {

--- a/src/boundary-list.js
+++ b/src/boundary-list.js
@@ -1,5 +1,5 @@
 import { Boundary } from './boundary';
-import { cssSelector, linkQuery } from './selector';
+import { cssSelector, linkQuery, linkQueryLazy } from './selector';
 import { applyStylesToNodes, attachDivOverlay } from './mutator';
 
 export class BoundaryList {
@@ -43,6 +43,14 @@ export class BoundaryList {
         });
     }
 
+    performBoundaryAction(boundary, nodes) {
+        if (boundary.action == 'disable') {
+            boundary.actionStyle = {'pointer-events': 'none'};
+        }
+        applyStylesToNodes(nodes, boundary.actionStyle);
+        return nodes;
+    }
+
     /*
         Apply a given boundary, performing the relevant DOM modifications.
         @param boundary: the given Boundary object
@@ -58,12 +66,17 @@ export class BoundaryList {
         if (boundary.action == 'inline-style') {
             matchedNodes = inlineStyle(document.head, boundary.actionStyle, boundary.selector);
         } else {
+<<<<<<< HEAD
             matchedNodes = selectorFuncs[boundary.selectorType](node, boundary.selector, this.host, this.cdxEndpoint).then(function(nodes) {
             if (boundary.action == 'disable') {
                     boundary.actionStyle = {'pointer-events': 'none'};
                 }
                 applyStylesToNodes(nodes, boundary.actionStyle);
                 return nodes;
+=======
+            matchedNodes = selectorFuncs[boundary.selectorType](node, boundary).then(function(nodes) {
+                this.performBoundaryAction(boundary, nodes);
+>>>>>>> Adding correct styling on lazy link query
             }.bind(this));
         }
         // Update the list of added nodes, and attach overlays if applicable
@@ -84,6 +97,13 @@ export class BoundaryList {
         let runningBoundaries = [];
         // Should always apply boundaries once on DOM load, whether or not the boundary is 'observer' type or not
         this.boundaries.forEach(function (boundary) {
+            if (boundary.selectorType === 'link-query-lazy') {
+                linkQueryLazy(document.body, boundary, function(node) {
+                    console.log(node);
+                    performBoundaryAction(boundary, node);
+                    boundary.pushAddedNodes(node);
+                })
+            }
             if (boundary.type == 'observer') {
                 observerBoundaries.push(boundary);
             }

--- a/src/boundary-list.js
+++ b/src/boundary-list.js
@@ -16,6 +16,7 @@ export class BoundaryList {
 
     /*
         Creates elements corresponding to a boundary's overlays.
+        @param nodes: the nodes to which to attach boundaries.
         @param boundary: the given Boundary object.
     */
    createOverlays(nodes, boundary) {
@@ -27,7 +28,9 @@ export class BoundaryList {
 
             let className = overlay.type == 'tooltip' ? 'overlay-tooltip' : 'overlay';
             let desc = overlay.type == 'tooltip' ? boundary.description : null;
-            boundary.overlayDivs[overlayId] = [];
+            if (boundary.overlayDivs[overlayId] === undefined) {
+                boundary.overlayDivs[overlayId] = [];
+            }
 
             nodes.forEach(function (node) {
                 let overlayDiv = attachDivOverlay(node, className, desc, overlay.styles);

--- a/src/boundary-list.js
+++ b/src/boundary-list.js
@@ -29,7 +29,6 @@ export class BoundaryList {
             let desc = overlay.type == 'tooltip' ? boundary.description : null;
             boundary.overlayDivs[overlayId] = [];
 
-            console.log(nodes);
             nodes.forEach(function (node) {
                 let overlayDiv = attachDivOverlay(node, className, desc, overlay.styles);
                 boundary.overlayDivs[overlayId].push(overlayDiv);
@@ -88,8 +87,6 @@ export class BoundaryList {
         this.boundaries.forEach(function (boundary) {
             if (boundary.selectorType === 'link-query-lazy') {
                 linkQueryLazy(boundary, document.body, function(node) {
-                    console.log('test');
-                    console.log(node);
                     this.performBoundaryAction([node], boundary);
                     boundary.pushAddedNodes([node]);
                     if (boundary.overlays !== undefined) {

--- a/src/boundary-list.js
+++ b/src/boundary-list.js
@@ -31,7 +31,6 @@ export class BoundaryList {
             let desc = overlay.type == 'tooltip' ? boundary.description : null;
             boundary.overlayDivs[overlayId] = [];
 
-            console.log(nodes);
             nodes.forEach(function (node) {
                 let overlayDiv = attachDivOverlay(node, className, desc, overlay.styles);
                 boundary.overlayDivs[overlayId].push(overlayDiv);
@@ -90,8 +89,6 @@ export class BoundaryList {
         this.boundaries.forEach(function (boundary) {
             if (boundary.selectorType === 'link-query-lazy') {
                 linkQueryLazy(boundary, document.body, function(node) {
-                    console.log('test');
-                    console.log(node);
                     this.performBoundaryAction([node], boundary);
                     boundary.pushAddedNodes([node]);
                     if (boundary.overlays !== undefined) {

--- a/src/boundary-list.js
+++ b/src/boundary-list.js
@@ -69,11 +69,7 @@ export class BoundaryList {
         if (boundary.action == 'inline-style') {
             matchedNodes = inlineStyle(document.head, boundary.actionStyle, boundary.selector);
         } else {
-<<<<<<< HEAD
             matchedNodes = selectorFuncs[boundary.selectorType](node, boundary.selector, this.host, this.cdxEndpoint).then(function(nodes) {
-=======
-            matchedNodes = selectorFuncs[boundary.selectorType](node, boundary).then(function(nodes) {
->>>>>>> 5eed16d11042e0da1bcd824576ae113cfce8d28c
                 return this.performBoundaryAction(nodes, boundary);
             }.bind(this));
         }
@@ -95,7 +91,7 @@ export class BoundaryList {
         // Should always apply boundaries once on DOM load, whether or not the boundary is 'observer' type or not
         this.boundaries.forEach(function (boundary) {
             if (boundary.selectorType === 'link-query-lazy') {
-                linkQueryLazy(boundary, document.body, function(node) {
+                linkQueryLazy(boundary, document.body, this.host, this.cdxEndpoint, function(node) {
                     this.performBoundaryAction([node], boundary);
                     boundary.pushAddedNodes([node]);
                     if (boundary.overlays !== undefined) {

--- a/src/boundary-list.js
+++ b/src/boundary-list.js
@@ -92,7 +92,8 @@ export class BoundaryList {
                     console.log(node);
                     this.performBoundaryAction([node], boundary);
                     boundary.pushAddedNodes([node]);
-                }.bind(this))
+                }.bind(this));
+                onLoadCallback(boundary);
             } else {
                 if (boundary.type == 'observer') {
                     observerBoundaries.push(boundary);

--- a/src/boundary-list.js
+++ b/src/boundary-list.js
@@ -29,6 +29,7 @@ export class BoundaryList {
             let desc = overlay.type == 'tooltip' ? boundary.description : null;
             boundary.overlayDivs[overlayId] = [];
 
+            console.log(nodes);
             nodes.forEach(function (node) {
                 let overlayDiv = attachDivOverlay(node, className, desc, overlay.styles);
                 boundary.overlayDivs[overlayId].push(overlayDiv);

--- a/src/boundary-list.js
+++ b/src/boundary-list.js
@@ -93,7 +93,8 @@ export class BoundaryList {
                     console.log(node);
                     this.performBoundaryAction([node], boundary);
                     boundary.pushAddedNodes([node]);
-                }.bind(this))
+                }.bind(this));
+                onLoadCallback(boundary);
             } else {
                 if (boundary.type == 'observer') {
                     observerBoundaries.push(boundary);

--- a/src/boundary-list.js
+++ b/src/boundary-list.js
@@ -56,7 +56,7 @@ export class BoundaryList {
         if (boundary.action == 'inline-style') {
             matchedNodes = inlineStyle(document.head, boundary.actionStyle, boundary.selector);
         } else {
-            matchedNodes = selectorFuncs[boundary.selectorType](node, boundary.selector).then(function(nodes) {
+            matchedNodes = selectorFuncs[boundary.selectorType](node, boundary).then(function(nodes) {
             if (boundary.action == 'disable') {
                     boundary.actionStyle = {'pointer-events': 'none'};
                 }

--- a/src/boundary-list.js
+++ b/src/boundary-list.js
@@ -43,7 +43,7 @@ export class BoundaryList {
         });
     }
 
-    performBoundaryAction(boundary, nodes) {
+    performBoundaryAction(nodes, boundary) {
         if (boundary.action == 'disable') {
             boundary.actionStyle = {'pointer-events': 'none'};
         }
@@ -56,7 +56,7 @@ export class BoundaryList {
         @param boundary: the given Boundary object
         @param node: the root DOM node from which to apply the boundary
     */
-    applyBoundary(boundary, node) {
+    applyBoundary(node, boundary) {
         let selectorFuncs = {
             'css-selector': cssSelector,
             'link-query': linkQuery
@@ -66,17 +66,8 @@ export class BoundaryList {
         if (boundary.action == 'inline-style') {
             matchedNodes = inlineStyle(document.head, boundary.actionStyle, boundary.selector);
         } else {
-<<<<<<< HEAD
             matchedNodes = selectorFuncs[boundary.selectorType](node, boundary.selector, this.host, this.cdxEndpoint).then(function(nodes) {
-            if (boundary.action == 'disable') {
-                    boundary.actionStyle = {'pointer-events': 'none'};
-                }
-                applyStylesToNodes(nodes, boundary.actionStyle);
-                return nodes;
-=======
-            matchedNodes = selectorFuncs[boundary.selectorType](node, boundary).then(function(nodes) {
-                this.performBoundaryAction(boundary, nodes);
->>>>>>> Adding correct styling on lazy link query
+                return this.performBoundaryAction(nodes, boundary);
             }.bind(this));
         }
         // Update the list of added nodes, and attach overlays if applicable
@@ -98,22 +89,23 @@ export class BoundaryList {
         // Should always apply boundaries once on DOM load, whether or not the boundary is 'observer' type or not
         this.boundaries.forEach(function (boundary) {
             if (boundary.selectorType === 'link-query-lazy') {
-                linkQueryLazy(document.body, boundary, function(node) {
+                linkQueryLazy(boundary, document.body, function(node) {
                     console.log(node);
-                    performBoundaryAction(boundary, node);
-                    boundary.pushAddedNodes(node);
-                })
-            }
-            if (boundary.type == 'observer') {
-                observerBoundaries.push(boundary);
-            }
-            let boundaryStatus = this.applyBoundary(boundary, document.body);
-            runningBoundaries.push(boundaryStatus);
-            boundaryStatus.then((boundary) => {
-                if (onLoadCallback) {
-                    onLoadCallback(boundary);
+                    this.performBoundaryAction([node], boundary);
+                    boundary.pushAddedNodes([node]);
+                }.bind(this))
+            } else {
+                if (boundary.type == 'observer') {
+                    observerBoundaries.push(boundary);
                 }
-            });   
+                let boundaryStatus = this.applyBoundary(document.body, boundary);
+                runningBoundaries.push(boundaryStatus);
+                boundaryStatus.then((boundary) => {
+                    if (onLoadCallback) {
+                        onLoadCallback(boundary);
+                    }
+                });       
+            }
         }.bind(this));
 
     
@@ -140,7 +132,7 @@ export class BoundaryList {
                     // To all added nodes, apply any applicable boundaries
                     mutation.addedNodes.forEach(function (node) {
                         observerBoundaries.forEach(function(boundary) {
-                            this.applyBoundary(boundary, node);
+                            this.applyBoundary(node, boundary);
                         }.bind(this));
                     });
                                         

--- a/src/boundary-list.js
+++ b/src/boundary-list.js
@@ -65,16 +65,14 @@ export class BoundaryList {
         if (boundary.action == 'inline-style') {
             matchedNodes = inlineStyle(document.head, boundary.actionStyle, boundary.selector);
         } else {
-            console.log(selectorFuncs[boundary.selectorType](node, boundary));
             matchedNodes = selectorFuncs[boundary.selectorType](node, boundary).then(function(nodes) {
                 return this.performBoundaryAction(nodes, boundary);
             }.bind(this));
         }
         // Update the list of added nodes, and attach overlays if applicable
         return matchedNodes.then(function(nodes) {
-            boundary.pushAddedNodes(nodes);
             if (boundary.overlays !== undefined) {
-                this.createOverlays(matchedNodes, boundary);
+                this.createOverlays(nodes, boundary);
             }
             return boundary;
         }.bind(this));    
@@ -90,6 +88,7 @@ export class BoundaryList {
         this.boundaries.forEach(function (boundary) {
             if (boundary.selectorType === 'link-query-lazy') {
                 linkQueryLazy(boundary, document.body, function(node) {
+                    console.log('test');
                     console.log(node);
                     this.performBoundaryAction([node], boundary);
                     boundary.pushAddedNodes([node]);

--- a/src/boundary-list.js
+++ b/src/boundary-list.js
@@ -18,6 +18,7 @@ export class BoundaryList {
 
     /*
         Creates elements corresponding to a boundary's overlays.
+        @param nodes: the nodes to which to attach boundaries.
         @param boundary: the given Boundary object.
     */
    createOverlays(nodes, boundary) {
@@ -29,7 +30,9 @@ export class BoundaryList {
 
             let className = overlay.type == 'tooltip' ? 'overlay-tooltip' : 'overlay';
             let desc = overlay.type == 'tooltip' ? boundary.description : null;
-            boundary.overlayDivs[overlayId] = [];
+            if (boundary.overlayDivs[overlayId] === undefined) {
+                boundary.overlayDivs[overlayId] = [];
+            }
 
             nodes.forEach(function (node) {
                 let overlayDiv = attachDivOverlay(node, className, desc, overlay.styles);

--- a/src/boundary-list.js
+++ b/src/boundary-list.js
@@ -20,7 +20,7 @@ export class BoundaryList {
         Creates elements corresponding to a boundary's overlays.
         @param boundary: the given Boundary object.
     */
-   createOverlays(boundary) {
+   createOverlays(nodes, boundary) {
         if (boundary.overlayDivs == undefined) {
             boundary.overlayDivs = {};
         }
@@ -31,7 +31,7 @@ export class BoundaryList {
             let desc = overlay.type == 'tooltip' ? boundary.description : null;
             boundary.overlayDivs[overlayId] = [];
 
-            boundary.affectedNodes.forEach(function (node) {
+            nodes.forEach(function (node) {
                 let overlayDiv = attachDivOverlay(node, className, desc, overlay.styles);
                 boundary.overlayDivs[overlayId].push(overlayDiv);
                 node.style.position = 'relative';
@@ -74,7 +74,7 @@ export class BoundaryList {
         return matchedNodes.then(function(nodes) {
             boundary.pushAddedNodes(nodes);
             if (boundary.overlays !== undefined) {
-                this.createOverlays(boundary);
+                this.createOverlays(matchedNodes, boundary);
             }
             return boundary;
         }.bind(this));    
@@ -93,6 +93,9 @@ export class BoundaryList {
                     console.log(node);
                     this.performBoundaryAction([node], boundary);
                     boundary.pushAddedNodes([node]);
+                    if (boundary.overlays !== undefined) {
+                        this.createOverlays([node], boundary);
+                    }
                 }.bind(this));
                 onLoadCallback(boundary);
             } else {

--- a/src/boundary-sidebar.js
+++ b/src/boundary-sidebar.js
@@ -190,13 +190,20 @@ export class BoundarySidebar extends LitElement {
         let oldVal = this._boundaries;
         this._boundaries = new BoundaryList(value, this.hostPrefix, this.cdxEndpoint);
         this.boundariesApplied = this._boundaries.applyBoundaries(function(boundary) {
+            if (this.boundaryElemClasses[boundary.idx] === undefined) {
+                this.boundaryElemClasses[boundary.idx] = {};
+            }
             this.boundaryElemClasses[boundary.idx].loading = false;
+            console.log(this.boundaryElemClasses)
             this.requestUpdate();
         }.bind(this));
 
         // Set up stylng for overlay divs and UI list element
         this._boundaries.boundaries.forEach((boundary) => {
-            this.boundaryElemClasses[boundary.idx] = {"boundary": true, "loading": true};
+            if (this.boundaryElemClasses[boundary.idx] === undefined) {
+                this.boundaryElemClasses[boundary.idx] = {"loading": true}
+            }
+            this.boundaryElemClasses[boundary.idx].boundary = true;
             this.boundaryDefaultOverlays[boundary.idx] = false;
         })
         this.requestUpdate();

--- a/src/boundary-sidebar.js
+++ b/src/boundary-sidebar.js
@@ -188,13 +188,20 @@ export class BoundarySidebar extends LitElement {
         let oldVal = this._boundaries;
         this._boundaries = new BoundaryList(value);
         this.boundariesApplied = this._boundaries.applyBoundaries(function(boundary) {
+            if (this.boundaryElemClasses[boundary.idx] === undefined) {
+                this.boundaryElemClasses[boundary.idx] = {};
+            }
             this.boundaryElemClasses[boundary.idx].loading = false;
+            console.log(this.boundaryElemClasses)
             this.requestUpdate();
         }.bind(this));
 
         // Set up stylng for overlay divs and UI list element
         this._boundaries.boundaries.forEach((boundary) => {
-            this.boundaryElemClasses[boundary.idx] = {"boundary": true, "loading": true};
+            if (this.boundaryElemClasses[boundary.idx] === undefined) {
+                this.boundaryElemClasses[boundary.idx] = {"loading": true}
+            }
+            this.boundaryElemClasses[boundary.idx].boundary = true;
             this.boundaryDefaultOverlays[boundary.idx] = false;
         })
         this.requestUpdate();

--- a/src/boundary-sidebar.js
+++ b/src/boundary-sidebar.js
@@ -187,24 +187,17 @@ export class BoundarySidebar extends LitElement {
     set boundaries(value) {
         let oldVal = this._boundaries;
         this._boundaries = new BoundaryList(value);
-        this.boundariesApplied = this._boundaries.applyBoundaries(function(boundary) {
-            if (this.boundaryElemClasses[boundary.idx] === undefined) {
-                this.boundaryElemClasses[boundary.idx] = {};
-            }
-            this.boundaryElemClasses[boundary.idx].loading = false;
-            console.log(this.boundaryElemClasses)
-            this.requestUpdate();
-        }.bind(this));
-
         // Set up stylng for overlay divs and UI list element
         this._boundaries.boundaries.forEach((boundary) => {
-            if (this.boundaryElemClasses[boundary.idx] === undefined) {
-                this.boundaryElemClasses[boundary.idx] = {"loading": true}
-            }
-            this.boundaryElemClasses[boundary.idx].boundary = true;
+            this.boundaryElemClasses[boundary.idx] = {"loading": true, "boundary": true}
             this.boundaryDefaultOverlays[boundary.idx] = false;
         })
-        this.requestUpdate();
+        
+        this.boundariesApplied = this._boundaries.applyBoundaries(function(boundary) {
+            this.boundaryElemClasses[boundary.idx].loading = false;
+            this.requestUpdate();
+        }.bind(this));
+        this.requestUpdate('boundaries', oldVal);
     }
 
     applyBoundaries(callback) {

--- a/src/boundary-sidebar.js
+++ b/src/boundary-sidebar.js
@@ -189,24 +189,17 @@ export class BoundarySidebar extends LitElement {
     set boundaries(value) {
         let oldVal = this._boundaries;
         this._boundaries = new BoundaryList(value, this.hostPrefix, this.cdxEndpoint);
-        this.boundariesApplied = this._boundaries.applyBoundaries(function(boundary) {
-            if (this.boundaryElemClasses[boundary.idx] === undefined) {
-                this.boundaryElemClasses[boundary.idx] = {};
-            }
-            this.boundaryElemClasses[boundary.idx].loading = false;
-            console.log(this.boundaryElemClasses)
-            this.requestUpdate();
-        }.bind(this));
-
         // Set up stylng for overlay divs and UI list element
         this._boundaries.boundaries.forEach((boundary) => {
-            if (this.boundaryElemClasses[boundary.idx] === undefined) {
-                this.boundaryElemClasses[boundary.idx] = {"loading": true}
-            }
-            this.boundaryElemClasses[boundary.idx].boundary = true;
+            this.boundaryElemClasses[boundary.idx] = {"loading": true, "boundary": true}
             this.boundaryDefaultOverlays[boundary.idx] = false;
         })
-        this.requestUpdate();
+        
+        this.boundariesApplied = this._boundaries.applyBoundaries(function(boundary) {
+            this.boundaryElemClasses[boundary.idx].loading = false;
+            this.requestUpdate();
+        }.bind(this));
+        this.requestUpdate('boundaries', oldVal);
     }
 
     applyBoundaries(callback) {

--- a/src/boundary.js
+++ b/src/boundary.js
@@ -17,7 +17,7 @@ export class Boundary {
         if (boundary.selector === undefined) {
             throw new TypeError('Boundary selector not provided.')
         }
-        if (boundary.selector.type !== 'css-selector' && boundary.selector.type !== 'link-query' && boundary.selector.type !== 'element-selector') {
+        if (boundary.selector.type !== 'css-selector' && boundary.selector.type !== 'link-query' && boundary.selector.type !== 'link-query-lazy') {
             throw new TypeError('Incorrect boundary selector type.')
         }
         this.selectorType = boundary.selector.type;

--- a/src/overlay.js
+++ b/src/overlay.js
@@ -13,7 +13,7 @@ export class Overlay extends LitElement {
             left: 0;
             right: 0;
             background-color: rgba(0,0,0,0.5);
-            z-index: -1;
+            z-index: 9998;
             pointer-events: none;
         }
 

--- a/src/selector.js
+++ b/src/selector.js
@@ -53,13 +53,17 @@ export function linkQueryLazy(_, node, host, endpoint, callback) {
         let allHrefNodes = node.querySelectorAll('[href]');
         let allLinkResults = {};
         let queryCallback = getLinkQueryCallback(host, endpoint, allLinkResults, callback);
+        let observerOptions = {
+            rootMargin: '15px',
+            threshold: 0.1
+        }
 
         allHrefNodes.forEach(function(node) {
             let observer;
             let unobserveCallback = () => {
                 observer.disconnect();
             }
-            observer = new IntersectionObserver(getIntersectionCallback(queryCallback, unobserveCallback));
+            observer = new IntersectionObserver(getIntersectionCallback(queryCallback, unobserveCallback), observerOptions);
             observer.observe(node);
         })
     }

--- a/src/selector.js
+++ b/src/selector.js
@@ -20,6 +20,7 @@ function getLinkQueryCallback(queryResults, otherCallback) {
             } else {
                 queryResource(href).then((isPresent) => {
                     queryResults[href] = isPresent;
+                    console.log
                     if (!isPresent) {
                         otherCallback(elem);
                     }

--- a/src/selector.js
+++ b/src/selector.js
@@ -35,41 +35,90 @@ function buildHrefListDedup(nodes) {
     return allHrefDedup;
 }
 
+class IntersectionElement {
+    constructor(boundary, hrefs) {
+        this.boundary = boundary;
+        this.hrefs = hrefs;
+        this.unobserveCallback = null;
+    }
+
+    intersectionCallback(entries) {
+        let elem = entries[0];
+        if (elem.intersectionRatio <= 0) return;
+        console.log('observed');
+    
+        let href = elem.target.href;
+        if (this.hrefs[href] !== undefined) {
+        } else {
+            queryResource(href).then((isPresent) => {
+                this.hrefs[href] = isPresent;
+            })
+        }
+        if (this.unobserveCallback !== null) {
+            this.unobserveCallback(elem.target);
+        }
+    }    
+}
+
+
+/*
+    > push all [href] query matching nodes to a list of nodes to query
+    > Create deduped list of hrefs
+    > on intersection:
+        > if href has already been queried, return result and unobserve target
+        > else, query node link
+*/
+
+
 /*
     Selects all elements with href attribute and queries whether they point to an in-boundary resource
 */
-export function linkQuery(node) {
+export function linkQuery(node, boundary) {
     if (node && node.nodeType === Node.ELEMENT_NODE) {
         let allHrefNodes = node.querySelectorAll('[href]');
         let allHrefsDedup = buildHrefListDedup(allHrefNodes);
         let allLinkPromises = [];
+        let allLinkResults = {};
+
+
+        console.log(allHrefNodes.length)
+        allHrefNodes.forEach(function(node) {
+            let intersectionElem = new IntersectionElement(boundary, allLinkResults);
+            let observer = new IntersectionObserver(intersectionElem.intersectionCallback.bind(intersectionElem));
+            intersectionElem.unobserveCallback = (elem) => {
+                observer.unobserve(elem);
+            }
+            observer.observe(node);
+        })
 
         // Query all deduped hrefs and correspond with their in-boundary status
-        allHrefsDedup.forEach(function(href) {
-            allLinkPromises.push(queryResource(href)
-                .then((isPresent) => {
-                    return [href, isPresent];
-                })
-            );
-        }); 
+        // allHrefsDedup.forEach(function(href) {
+        //     allLinkPromises.push(queryResource(href)
+        //         .then((isPresent) => {
+        //             return [href, isPresent];
+        //         })
+        //     );
+        // }); 
 
-        return Promise.all(allLinkPromises).then((nodes) => {
-            let allLinkResults = {};
-            nodes.forEach(function (node) {
-                allLinkResults[node[0]] = node[1];
-            })
+        // return Promise.all(allLinkPromises).then((nodes) => {
+        //     let allLinkResults = {};
+        //     nodes.forEach(function (node) {
+        //         allLinkResults[node[0]] = node[1];
+        //     })
 
-            let filteredNodes = [];
-            allHrefNodes.forEach(function (node) {
-                if (!allLinkResults[node.href]) {
-                    filteredNodes.push(node);
-                }
-            })
-            return filteredNodes;
-        })
+        //     let filteredNodes = [];
+        //     allHrefNodes.forEach(function (node) {
+        //         if (!allLinkResults[node.href]) {
+        //             filteredNodes.push(node);
+        //         }
+        //     })
+        //     return filteredNodes;
+        // })
+
+        return new Promise((res) => res([]));
     }
 }
 
-export function cssSelector(node, selector) {
-    return new Promise((resolve) => {resolve(node.querySelectorAll(selector))});
+export function cssSelector(node, boundary) {
+    return new Promise((resolve) => {resolve(node.querySelectorAll(boundary.selector))});
 }

--- a/src/selector.js
+++ b/src/selector.js
@@ -1,3 +1,27 @@
+class IntersectionElement {
+    constructor(boundary, hrefs, presentCallback) {
+        this.boundary = boundary;
+        this.hrefs = hrefs;
+        this.unobserveCallback = null;
+    }
+
+    intersectionCallback(entries) {
+        let elem = entries[0];
+        if (elem.intersectionRatio <= 0) return;
+        console.log('observed');
+    
+        let href = elem.target.href;
+        if (this.hrefs[href] !== undefined) {
+        } else {
+            queryResource(href).then((isPresent) => {
+                this.hrefs[href] = isPresent;
+            })
+        }
+        if (this.unobserveCallback !== null) {
+            this.unobserveCallback(elem.target);
+        }
+    }    
+}
 
 /*
     Determine whether a given backend CDX query returns a result.
@@ -35,32 +59,6 @@ function buildHrefListDedup(nodes) {
     return allHrefDedup;
 }
 
-class IntersectionElement {
-    constructor(boundary, hrefs) {
-        this.boundary = boundary;
-        this.hrefs = hrefs;
-        this.unobserveCallback = null;
-    }
-
-    intersectionCallback(entries) {
-        let elem = entries[0];
-        if (elem.intersectionRatio <= 0) return;
-        console.log('observed');
-    
-        let href = elem.target.href;
-        if (this.hrefs[href] !== undefined) {
-        } else {
-            queryResource(href).then((isPresent) => {
-                this.hrefs[href] = isPresent;
-            })
-        }
-        if (this.unobserveCallback !== null) {
-            this.unobserveCallback(elem.target);
-        }
-    }    
-}
-
-
 /*
     > push all [href] query matching nodes to a list of nodes to query
     > Create deduped list of hrefs
@@ -69,6 +67,23 @@ class IntersectionElement {
         > else, query node link
 */
 
+export function linkQuery(node, boundary) {
+    if (node && node.nodeType === Node.ELEMENT_NODE) {
+        let allHrefNodes = node.querySelectorAll('[href]');
+        let allLinkResults = {};
+
+
+        console.log(allHrefNodes.length)
+        allHrefNodes.forEach(function(node) {
+            let intersectionElem = new IntersectionElement(boundary, allLinkResults);
+            let observer = new IntersectionObserver(intersectionElem.intersectionCallback.bind(intersectionElem));
+            intersectionElem.unobserveCallback = (elem) => {
+                observer.disconnect();
+            }
+            observer.observe(node);
+        })
+    }
+}
 
 /*
     Selects all elements with href attribute and queries whether they point to an in-boundary resource
@@ -78,44 +93,30 @@ export function linkQuery(node, boundary) {
         let allHrefNodes = node.querySelectorAll('[href]');
         let allHrefsDedup = buildHrefListDedup(allHrefNodes);
         let allLinkPromises = [];
-        let allLinkResults = {};
-
-
-        console.log(allHrefNodes.length)
-        allHrefNodes.forEach(function(node) {
-            let intersectionElem = new IntersectionElement(boundary, allLinkResults);
-            let observer = new IntersectionObserver(intersectionElem.intersectionCallback.bind(intersectionElem));
-            intersectionElem.unobserveCallback = (elem) => {
-                observer.unobserve(elem);
-            }
-            observer.observe(node);
-        })
 
         // Query all deduped hrefs and correspond with their in-boundary status
-        // allHrefsDedup.forEach(function(href) {
-        //     allLinkPromises.push(queryResource(href)
-        //         .then((isPresent) => {
-        //             return [href, isPresent];
-        //         })
-        //     );
-        // }); 
+        allHrefsDedup.forEach(function(href) {
+            allLinkPromises.push(queryResource(href)
+                .then((isPresent) => {
+                    return [href, isPresent];
+                })
+            );
+        }); 
 
-        // return Promise.all(allLinkPromises).then((nodes) => {
-        //     let allLinkResults = {};
-        //     nodes.forEach(function (node) {
-        //         allLinkResults[node[0]] = node[1];
-        //     })
+        return Promise.all(allLinkPromises).then((nodes) => {
+            let allLinkResults = {};
+            nodes.forEach(function (node) {
+                allLinkResults[node[0]] = node[1];
+            })
 
-        //     let filteredNodes = [];
-        //     allHrefNodes.forEach(function (node) {
-        //         if (!allLinkResults[node.href]) {
-        //             filteredNodes.push(node);
-        //         }
-        //     })
-        //     return filteredNodes;
-        // })
-
-        return new Promise((res) => res([]));
+            let filteredNodes = [];
+            allHrefNodes.forEach(function (node) {
+                if (!allLinkResults[node.href]) {
+                    filteredNodes.push(node);
+                }
+            })
+            return filteredNodes;
+        })
     }
 }
 

--- a/src/selector.js
+++ b/src/selector.js
@@ -1,3 +1,27 @@
+class IntersectionElement {
+    constructor(boundary, hrefs, presentCallback) {
+        this.boundary = boundary;
+        this.hrefs = hrefs;
+        this.unobserveCallback = null;
+    }
+
+    intersectionCallback(entries) {
+        let elem = entries[0];
+        if (elem.intersectionRatio <= 0) return;
+        console.log('observed');
+    
+        let href = elem.target.href;
+        if (this.hrefs[href] !== undefined) {
+        } else {
+            queryResource(href).then((isPresent) => {
+                this.hrefs[href] = isPresent;
+            })
+        }
+        if (this.unobserveCallback !== null) {
+            this.unobserveCallback(elem.target);
+        }
+    }    
+}
 
 /*
     Determine whether a given backend CDX query returns a result.
@@ -35,32 +59,6 @@ function buildHrefListDedup(nodes) {
     return allHrefDedup;
 }
 
-class IntersectionElement {
-    constructor(boundary, hrefs) {
-        this.boundary = boundary;
-        this.hrefs = hrefs;
-        this.unobserveCallback = null;
-    }
-
-    intersectionCallback(entries) {
-        let elem = entries[0];
-        if (elem.intersectionRatio <= 0) return;
-        console.log('observed');
-    
-        let href = elem.target.href;
-        if (this.hrefs[href] !== undefined) {
-        } else {
-            queryResource(href).then((isPresent) => {
-                this.hrefs[href] = isPresent;
-            })
-        }
-        if (this.unobserveCallback !== null) {
-            this.unobserveCallback(elem.target);
-        }
-    }    
-}
-
-
 /*
     > push all [href] query matching nodes to a list of nodes to query
     > Create deduped list of hrefs
@@ -76,8 +74,6 @@ class IntersectionElement {
 export function linkQuery(node, _, host, endpoint) {
     if (node && node.nodeType === Node.ELEMENT_NODE) {
         let allHrefNodes = node.querySelectorAll('[href]');
-        let allHrefsDedup = buildHrefListDedup(allHrefNodes);
-        let allLinkPromises = [];
         let allLinkResults = {};
 
 
@@ -86,36 +82,45 @@ export function linkQuery(node, _, host, endpoint) {
             let intersectionElem = new IntersectionElement(boundary, allLinkResults);
             let observer = new IntersectionObserver(intersectionElem.intersectionCallback.bind(intersectionElem));
             intersectionElem.unobserveCallback = (elem) => {
-                observer.unobserve(elem);
+                observer.disconnect();
             }
             observer.observe(node);
         })
+    }
+}
+
+/*
+    Selects all elements with href attribute and queries whether they point to an in-boundary resource
+*/
+export function linkQuery(node, boundary) {
+    if (node && node.nodeType === Node.ELEMENT_NODE) {
+        let allHrefNodes = node.querySelectorAll('[href]');
+        let allHrefsDedup = buildHrefListDedup(allHrefNodes);
+        let allLinkPromises = [];
 
         // Query all deduped hrefs and correspond with their in-boundary status
-        // allHrefsDedup.forEach(function(href) {
-        //     allLinkPromises.push(queryResource(href)
-        //         .then((isPresent) => {
-        //             return [href, isPresent];
-        //         })
-        //     );
-        // }); 
+        allHrefsDedup.forEach(function(href) {
+            allLinkPromises.push(queryResource(href)
+                .then((isPresent) => {
+                    return [href, isPresent];
+                })
+            );
+        }); 
 
-        // return Promise.all(allLinkPromises).then((nodes) => {
-        //     let allLinkResults = {};
-        //     nodes.forEach(function (node) {
-        //         allLinkResults[node[0]] = node[1];
-        //     })
+        return Promise.all(allLinkPromises).then((nodes) => {
+            let allLinkResults = {};
+            nodes.forEach(function (node) {
+                allLinkResults[node[0]] = node[1];
+            })
 
-        //     let filteredNodes = [];
-        //     allHrefNodes.forEach(function (node) {
-        //         if (!allLinkResults[node.href]) {
-        //             filteredNodes.push(node);
-        //         }
-        //     })
-        //     return filteredNodes;
-        // })
-
-        return new Promise((res) => res([]));
+            let filteredNodes = [];
+            allHrefNodes.forEach(function (node) {
+                if (!allLinkResults[node.href]) {
+                    filteredNodes.push(node);
+                }
+            })
+            return filteredNodes;
+        })
     }
 }
 

--- a/src/selector.js
+++ b/src/selector.js
@@ -8,6 +8,7 @@ class IntersectionElement {
 
     intersectionCallback(entries) {
         let elem = entries[0];
+        // If there is no intersection
         if (elem.intersectionRatio <= 0) return;
     
         let href = elem.target.href;
@@ -23,7 +24,7 @@ class IntersectionElement {
                 }
             })
         }
-        if (this.unobserveCallback !==null) {
+        if (this.unobserveCallback !== null) {
             this.unobserveCallback(elem.target);
         } 
     }    

--- a/src/selector.js
+++ b/src/selector.js
@@ -1,24 +1,25 @@
 class IntersectionElement {
-    constructor(boundary, hrefs, presentCallback) {
+    constructor(boundary, hrefs, callback) {
         this.boundary = boundary;
         this.hrefs = hrefs;
         this.unobserveCallback = null;
+        this.callback = callback;
     }
 
-    intersectionCallback(entries, onQueryCallback) {
+    intersectionCallback(entries) {
         let elem = entries[0];
         if (elem.intersectionRatio <= 0) return;
     
         let href = elem.target.href;
         if (this.hrefs[href] !== undefined) {
             if (this.hrefs[href] === false) {
-                onQueryCallback(elem.target);
+                this.callback(elem.target);
             }
         } else {
             queryResource(href).then((isPresent) => {
                 this.hrefs[href] = isPresent;
                 if (!isPresent) {
-                    onQueryCallback(elem.target);
+                    this.callback(elem.target);
                 }
             })
         }
@@ -32,7 +33,7 @@ class IntersectionElement {
     Uses an IntersectionObserver to perform link queries on elements only as they are loaded into view.
 */
 
-export function linkQueryLazy(node, boundary, callback) {
+export function linkQueryLazy(boundary, node, callback) {
     if (node && node.nodeType === Node.ELEMENT_NODE) {
         let allHrefNodes = node.querySelectorAll('[href]');
         let allLinkResults = {};
@@ -90,7 +91,7 @@ function buildHrefListDedup(nodes) {
 /*
     Selects all elements with href attribute and queries whether they point to an in-boundary resource
 */
-export function linkQuery(node, _) {
+export function linkQuery(node, boundary) {
     if (node && node.nodeType === Node.ELEMENT_NODE) {
         let allHrefNodes = node.querySelectorAll('[href]');
         let allHrefsDedup = buildHrefListDedup(allHrefNodes);

--- a/src/selector.js
+++ b/src/selector.js
@@ -19,7 +19,7 @@ function getIntersectionCallback(callback, unobserveCallback) {
     @param queryResults: an Object mapping from href values to their in-boundary status
     @param otherCallback: an upstream callback to be called on each out-of-boundary element
 */
-function getLinkQueryCallback(queryResults, otherCallback) {
+function getLinkQueryCallback(host, endpoint, queryResults, otherCallback) {
     return function(elem) {
         if (elem.href !== undefined) {
             let href = elem.href;
@@ -31,7 +31,7 @@ function getLinkQueryCallback(queryResults, otherCallback) {
                     }
                 })
             } else {
-                queryResults[href] = queryResource(href).then((isPresent) => {
+                queryResults[href] = queryResource(href, host, endpoint).then((isPresent) => {
                     if (!isPresent) {
                         otherCallback(elem);
                     }
@@ -48,11 +48,11 @@ function getLinkQueryCallback(queryResults, otherCallback) {
     @param node: the root HTML element from which to query
     @param callback: the function to be called with intersected elements to be passed into
 */
-export function linkQueryLazy(boundary, node, callback) {
+export function linkQueryLazy(_, node, host, endpoint, callback) {
     if (node && node.nodeType === Node.ELEMENT_NODE) {
         let allHrefNodes = node.querySelectorAll('[href]');
         let allLinkResults = {};
-        let queryCallback = getLinkQueryCallback(allLinkResults, callback);
+        let queryCallback = getLinkQueryCallback(host, endpoint, allLinkResults, callback);
 
         allHrefNodes.forEach(function(node) {
             let observer;

--- a/src/selector.js
+++ b/src/selector.js
@@ -105,7 +105,7 @@ function buildHrefListDedup(nodes) {
 /*
     Selects all elements with href attribute and queries whether they point to an in-boundary resource
 */
-export function linkQuery(node, boundary) {
+export function linkQuery(node, _, host, endpoint) {
     if (node && node.nodeType === Node.ELEMENT_NODE) {
         let allHrefNodes = node.querySelectorAll('[href]');
         let allHrefsDedup = buildHrefListDedup(allHrefNodes);
@@ -113,7 +113,7 @@ export function linkQuery(node, boundary) {
 
         // Query all deduped hrefs and correspond with their in-boundary status
         allHrefsDedup.forEach(function(href) {
-            allLinkPromises.push(queryResource(href)
+            allLinkPromises.push(queryResource(href, host, endpoint)
                 .then((isPresent) => {
                     return [href, isPresent];
                 })

--- a/src/selector.js
+++ b/src/selector.js
@@ -5,23 +5,51 @@ class IntersectionElement {
         this.unobserveCallback = null;
     }
 
-    intersectionCallback(entries) {
+    intersectionCallback(entries, onQueryCallback) {
         let elem = entries[0];
         if (elem.intersectionRatio <= 0) return;
-        console.log('observed');
     
         let href = elem.target.href;
         if (this.hrefs[href] !== undefined) {
+            if (this.hrefs[href] === false) {
+                onQueryCallback(elem.target);
+            }
         } else {
             queryResource(href).then((isPresent) => {
                 this.hrefs[href] = isPresent;
+                if (!isPresent) {
+                    onQueryCallback(elem.target);
+                }
             })
         }
-        if (this.unobserveCallback !== null) {
+        if (this.unobserveCallback !==null) {
             this.unobserveCallback(elem.target);
-        }
+        } 
     }    
 }
+
+/*
+    Uses an IntersectionObserver to perform link queries on elements only as they are loaded into view.
+*/
+
+export function linkQueryLazy(node, boundary, callback) {
+    if (node && node.nodeType === Node.ELEMENT_NODE) {
+        let allHrefNodes = node.querySelectorAll('[href]');
+        let allLinkResults = {};
+
+
+        console.log(allHrefNodes.length)
+        allHrefNodes.forEach(function(node) {
+            let intersectionElem = new IntersectionElement(boundary, allLinkResults, callback);
+            let observer = new IntersectionObserver(intersectionElem.intersectionCallback.bind(intersectionElem));
+            intersectionElem.unobserveCallback = () => {
+                observer.disconnect();
+            }
+            observer.observe(node);
+        })
+    }
+}
+
 
 /*
     Determine whether a given backend CDX query returns a result.
@@ -60,39 +88,9 @@ function buildHrefListDedup(nodes) {
 }
 
 /*
-    > push all [href] query matching nodes to a list of nodes to query
-    > Create deduped list of hrefs
-    > on intersection:
-        > if href has already been queried, return result and unobserve target
-        > else, query node link
-*/
-
-
-/*
     Selects all elements with href attribute and queries whether they point to an in-boundary resource
 */
-export function linkQuery(node, _, host, endpoint) {
-    if (node && node.nodeType === Node.ELEMENT_NODE) {
-        let allHrefNodes = node.querySelectorAll('[href]');
-        let allLinkResults = {};
-
-
-        console.log(allHrefNodes.length)
-        allHrefNodes.forEach(function(node) {
-            let intersectionElem = new IntersectionElement(boundary, allLinkResults);
-            let observer = new IntersectionObserver(intersectionElem.intersectionCallback.bind(intersectionElem));
-            intersectionElem.unobserveCallback = (elem) => {
-                observer.disconnect();
-            }
-            observer.observe(node);
-        })
-    }
-}
-
-/*
-    Selects all elements with href attribute and queries whether they point to an in-boundary resource
-*/
-export function linkQuery(node, boundary) {
+export function linkQuery(node, _) {
     if (node && node.nodeType === Node.ELEMENT_NODE) {
         let allHrefNodes = node.querySelectorAll('[href]');
         let allHrefsDedup = buildHrefListDedup(allHrefNodes);


### PR DESCRIPTION
Adds "lazy loading" options for link query boundaries. `selector.type` = `link-query-lazy` performs link querying, but only on intersection with the browser viewport, providing a slight optimization of initial boundary load times.